### PR TITLE
Add logging utils and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,13 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      - run: npx eslint . --max-warnings=0
+      - run: pnpm test

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,12 @@
+# BCOP Usage Guide
+
+## Setup
+- Copy `.env.sample` to `.env` and provide your OpenAI key in `VITE_OPENAI_KEY`.
+- Install dependencies with `pnpm install`.
+
+## Development
+- Run `pnpm dev` to start the app.
+
+## Testing
+- Execute `pnpm test` to run vitest.
+- CI runs linting and tests automatically via GitHub Actions.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "vitest run",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "eslint . --ext .ts,.tsx --fix",
     "preview": "serve dist -l 3000"

--- a/src/analysis/analysis-engine-core.ts
+++ b/src/analysis/analysis-engine-core.ts
@@ -1,5 +1,6 @@
 import { SYSTEM_PROMPT_ANALYSIS } from '@/prompts/systemPrompt';
 import { callGPTWithSystem } from '@/lib/openai';
+import { logError } from '@/utils/logger';
 
 export async function analyzeMessage(text: string) {
   const userPrompt = SYSTEM_PROMPT_ANALYSIS.replace(
@@ -7,11 +8,16 @@ export async function analyzeMessage(text: string) {
     text
   );
 
-  const raw = await callGPTWithSystem(
-    'Ты — аналитик банковских коммуникаций. Отвечай JSON-объектом.',
-    userPrompt,
-    { response_format: { type: 'json_object' } }
-  );
+  try {
+    const raw = await callGPTWithSystem(
+      'Ты — аналитик банковских коммуникаций. Отвечай JSON-объектом.',
+      userPrompt,
+      { response_format: { type: 'json_object' } }
+    );
 
-  return JSON.parse(raw as string);
+    return JSON.parse(raw as string);
+  } catch (e: any) {
+    logError(e, { text });
+    throw e;
+  }
 }

--- a/src/analysis/response-generator.ts
+++ b/src/analysis/response-generator.ts
@@ -1,5 +1,6 @@
 import { callGPTWithSystem } from '@/lib/openai';
 import { GeneratedResponses, ResponseGeneratorParams } from '@/types/response';
+import { logError } from '@/utils/logger';
 
 export async function generateResponses(params: ResponseGeneratorParams): Promise<GeneratedResponses> {
   const { goal, analysisResult } = params;
@@ -25,13 +26,12 @@ export async function generateResponses(params: ResponseGeneratorParams): Promis
       userPrompt,
       { response_format: { type: 'json_object' } }
     );
-
     return JSON.parse(response as string);
   } catch (error) {
-    console.error('Error generating responses:', error);
+    logError(error as Error, { goal });
     return {
       legal: 'Ошибка генерации юридического ответа',
-      professional: 'Ошибка генерации профессионального ответа', 
+      professional: 'Ошибка генерации профессионального ответа',
       sarcastic: 'Ошибка генерации саркастичного ответа'
     };
   }

--- a/src/lib/anonymizer.ts
+++ b/src/lib/anonymizer.ts
@@ -1,0 +1,8 @@
+export function sanitize(text: string): string {
+  // simple phone number redaction
+  const withoutPhones = text.replace(/\b\d{7,}\b/g, '[REDACTED]');
+
+  // rudimentary Russian name with initials: "Surname I.I." or "Surname F."
+  const namePattern = /[А-ЯA-Z][а-яa-z]+\s+[А-ЯA-Z]\.(?:[А-ЯA-Z]\.)?/g;
+  return withoutPhones.replace(namePattern, '[NAME]');
+}

--- a/src/utils/export-utils.ts
+++ b/src/utils/export-utils.ts
@@ -1,5 +1,6 @@
 import jsPDF from 'jspdf';
 import { DialogSession, DialogMessage } from '../store/useDialogHistory';
+import { logError } from '@/utils/logger';
 
 // Экспорт диалога в PDF
 export function exportDialogToPDF(session: DialogSession) {
@@ -7,12 +8,13 @@ export function exportDialogToPDF(session: DialogSession) {
     console.warn('No session data to export');
     return;
   }
-  
-  const doc = new jsPDF();
-  const pageHeight = doc.internal.pageSize.height;
-  let yPosition = 20;
-  const lineHeight = 7;
-  const maxLineWidth = 180;
+
+  try {
+    const doc = new jsPDF();
+    const pageHeight = doc.internal.pageSize.height;
+    let yPosition = 20;
+    const lineHeight = 7;
+    const maxLineWidth = 180;
 
   // Заголовок
   doc.setFontSize(16);
@@ -91,6 +93,9 @@ export function exportDialogToPDF(session: DialogSession) {
   // Сохранение файла
   const filename = `dialog_${session.startTime}_${Date.now()}.pdf`;
   doc.save(filename);
+  } catch (e: any) {
+    logError(e, { sessionId: session.id });
+  }
 }
 
 // Экспорт в CSV

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,11 @@
+export function logEvent(event: string, meta: any = {}) {
+  // Можно расширить до отправки на сервер или Sentry
+  console.info(`[BCOP]`, event, meta);
+}
+
+export function logError(error: Error | string, meta: any = {}) {
+  console.error(`[BCOP ERROR]`, error, meta);
+  if (typeof window !== 'undefined' && (window as any).toast) {
+    (window as any).toast.error?.(error.toString());
+  }
+}

--- a/tests/anonymizer.test.ts
+++ b/tests/anonymizer.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { sanitize } from '@/lib/anonymizer';
+
+describe('sanitize', () => {
+  it('редактирует ФИО', () => {
+    expect(sanitize('Иванов И.И.')).toContain('[NAME]');
+  });
+
+  it('скрывает номера', () => {
+    expect(sanitize('Ваш телефон 89991112233')).toContain('[REDACTED]');
+  });
+});

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, vi } from 'vitest';
+import { analyzeMessage } from '@/analysis/analysis-engine-core';
+import { generateResponses } from '@/analysis/response-generator';
+import * as openaiModule from '@/lib/openai';
+
+vi.mock('@/lib/openai');
+
+const mocked = vi.mocked(openaiModule);
+
+describe('integration: анализ и ответы', () => {
+  it('полный цикл без ошибок', async () => {
+    mocked.callGPTWithSystem
+      .mockResolvedValueOnce('{"tactics":"threat"}')
+      .mockResolvedValueOnce('{"legal":"law","professional":"business","sarcastic":"joke"}');
+
+    const msg = 'Если не оплатите — будет суд!';
+    const analysis = await analyzeMessage(msg);
+    expect(analysis.tactics).toContain('threat');
+    const responses = await generateResponses({ goal: 'delay_time', analysisResult: analysis });
+    expect(responses.legal).toMatch(/law/);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
     },
     "jsx": "react-jsx"
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules", "dist"]
 } 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config';
+import path from 'path';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add basic logger utility and wire it into OpenAI and other layers
- add sanitization helper and tests
- create vitest config and integration tests
- configure CI workflow for linting and tests
- add usage docs

## Testing
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.13.1.tgz)*
- `npx eslint . --max-warnings=0` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688367c69c1c83248e78090351ce3313