### PR TITLE
Improve TypeScript typings

### DIFF
--- a/src/analysis/analysis-engine-core.ts
+++ b/src/analysis/analysis-engine-core.ts
@@ -1,7 +1,8 @@
 import { SYSTEM_PROMPT_ANALYSIS } from '../prompts/systemPrompt';
 import { callGPTWithSystem } from '../lib/openai';
+import { AnalysisResult } from '../types/response';
 
-export async function analyzeMessage(text: string) {
+export async function analyzeMessage(text: string): Promise<AnalysisResult> {
   const userPrompt = SYSTEM_PROMPT_ANALYSIS.replace(
     '[ВСТАВЬ СЮДА ОДНО ИЛИ НЕСКОЛЬКО СООБЩЕНИЙ СО СТОРОНЫ ОПЕРАТОРА]',
     text
@@ -13,5 +14,5 @@ export async function analyzeMessage(text: string) {
     { response_format: { type: 'json_object' } }
   );
 
-  return JSON.parse(raw as string);
+  return JSON.parse(raw) as AnalysisResult;
 }

--- a/src/analysis/response-generator.ts
+++ b/src/analysis/response-generator.ts
@@ -26,7 +26,7 @@ export async function generateResponses(params: ResponseGeneratorParams): Promis
       { response_format: { type: 'json_object' } }
     );
 
-    return JSON.parse(response as string);
+    return JSON.parse(response) as GeneratedResponses;
   } catch (error) {
     console.error('Error generating responses:', error);
     return {

--- a/src/components/ResponseSelect.tsx
+++ b/src/components/ResponseSelect.tsx
@@ -7,7 +7,7 @@ import { Skeleton } from '@/components/ui';
 
 function safeParse(responses: string): GeneratedResponses | null {
   try {
-    return JSON.parse(responses);
+    return JSON.parse(responses) as GeneratedResponses;
   } catch {
     return null;
   }

--- a/src/components/ThreePanelDashboard.tsx
+++ b/src/components/ThreePanelDashboard.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { v4 as uuidv4 } from 'uuid'; // <--- ДОБАВЬТЕ ЭТУ СТРОКУ
 import { useMessageStore } from '../store/messageStore';
 import { useDialogHistory } from '../store/useDialogHistory';
-import { GeneratedResponses, AnalysisMessage } from '../types/response';
+import { GeneratedResponses, AnalysisMessage, AdaptedAnalysisResult, AnalysisResult } from '../types/response';
 // ... остальной код импортов
 import { analyzeMessage } from '../analysis/analysis-engine-core';
 import { generateResponses } from '../analysis/response-generator';
@@ -27,7 +27,7 @@ export default function ThreePanelDashboard() {
     setCurrentSession,
   } = useDialogHistory();
   
-  const [analysis, setAnalysis] = useState<any>(null);
+  const [analysis, setAnalysis] = useState<AdaptedAnalysisResult | null>(null);
   const [responses, setResponses] = useState<GeneratedResponses | null>(null);
   const [isAnalyzing, setIsAnalyzing] = useState(false);
 
@@ -56,7 +56,7 @@ export default function ThreePanelDashboard() {
 
     try {
       const rawAnalysis = await analyzeMessage(text);
-      const adaptedAnalysis = adaptAnalysisForGoal(rawAnalysis as any, 'defensive');
+      const adaptedAnalysis = adaptAnalysisForGoal(rawAnalysis, 'defensive');
       const generatedResponses = await generateResponses({
         goal: 'defensive',
         analysisResult: adaptedAnalysis,

--- a/src/goal-engine.ts
+++ b/src/goal-engine.ts
@@ -1,4 +1,5 @@
- // Goal Engine - влияет на tone и стратегию ответов GPT
+// Goal Engine - влияет на tone и стратегию ответов GPT
+import { AnalysisResult, AdaptedAnalysisResult, GoalAlignment } from './types/response';
 export type GoalType = 'defensive' | 'aggressive' | 'informational';
 
 export interface GoalStrategy {
@@ -106,11 +107,7 @@ ${styleModifier}
 }
 
 // Анализ соответствия сообщения выбранной цели
-export function analyzeGoalAlignment(message: string, goal: GoalType): {
-  alignment: number; // 0-100%
-  suggestions: string[];
-  missedOpportunities: string[];
-} {
+export function analyzeGoalAlignment(message: string, goal: GoalType): GoalAlignment {
   const strategy = GOAL_STRATEGIES[goal];
   const messageWords = message.toLowerCase().split(/\s+/);
   
@@ -174,7 +171,7 @@ export function getNextMessageRecommendations(goal: GoalType, _conversationHisto
 }
 
 // Адаптация анализа под цель
-export function adaptAnalysisForGoal(rawAnalysis: any, goal: GoalType): any {
+export function adaptAnalysisForGoal(rawAnalysis: AnalysisResult, goal: GoalType): AdaptedAnalysisResult {
   try {
     const strategy = GOAL_STRATEGIES[goal];
     
@@ -184,7 +181,7 @@ export function adaptAnalysisForGoal(rawAnalysis: any, goal: GoalType): any {
     }
     
     // Добавляем специфичные для цели метрики
-    const adaptedAnalysis = {
+    const adaptedAnalysis: AdaptedAnalysisResult = {
       ...rawAnalysis,
       goalStrategy: strategy.name,
       goalAlignment: analyzeGoalAlignment(rawAnalysis.originalMessage || '', goal),
@@ -216,6 +213,6 @@ export function adaptAnalysisForGoal(rawAnalysis: any, goal: GoalType): any {
   return adaptedAnalysis;
   } catch (error) {
     console.error('Error adapting analysis for goal:', error);
-    return rawAnalysis;
+    return rawAnalysis as AdaptedAnalysisResult;
   }
 }

--- a/src/store/useDialogHistory.ts
+++ b/src/store/useDialogHistory.ts
@@ -8,7 +8,7 @@ export interface DialogSession {
   messages: AnalysisMessage[];
 }
 
-interface Dialog { id: string; title: string; messages: any[] }
+interface Dialog { id: string; title: string; messages: AnalysisMessage[] }
 interface HistoryState {
   dialogs: Dialog[];
   activeId?: string;

--- a/src/types/response.d.ts
+++ b/src/types/response.d.ts
@@ -4,20 +4,41 @@ export interface GeneratedResponses {
   sarcastic: string;
 }
 
+export interface AnalysisResult {
+  originalMessage?: string;
+  legalViolations?: unknown[];
+  threats?: { detected: boolean };
+  collectorInfo?: { company?: string };
+  [key: string]: unknown;
+}
+
+export interface GoalAlignment {
+  alignment: number;
+  suggestions: string[];
+  missedOpportunities: string[];
+}
+
+export interface AdaptedAnalysisResult extends AnalysisResult {
+  goalStrategy: string;
+  goalAlignment: GoalAlignment;
+  recommendations: string[];
+  strategicOpportunities: string[];
+}
+
 export interface AnalysisMessage {
   id: string;
   timestamp: number;
   /** Кто отправил сообщение */
   author?: 'user' | 'assistant';
   originalText: string;
-  analysis: unknown; // результат из analyzeMessage
+  analysis: AdaptedAnalysisResult | AnalysisResult | null;
   responses?: GeneratedResponses;
   selectedResponse?: string;
 }
 
 export interface ResponseGeneratorParams {
   goal: string;
-  analysisResult: unknown;
+  analysisResult: AdaptedAnalysisResult;
 }
 
 export interface ResponseOption { style: string; text: unknown; }


### PR DESCRIPTION
## Summary
- add explicit GPT and analysis interfaces
- update OpenAI helper with typed options
- ensure analysis engine and response generator return typed results
- use strong types in dashboard and store
- parse response data safely

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'react')*
- `pnpm lint` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6883e0e535b0832488e78ca3d239fcec